### PR TITLE
Fix Amharic translation of positive-value-indicator

### DIFF
--- a/src/webui/_locales/am/messages.json
+++ b/src/webui/_locales/am/messages.json
@@ -640,7 +640,7 @@
         "description": "Label for a disabled button. The user has clicked the button in order to buy an hour of Speed Boost, and now the purchase is completing and Speed Boost is activating. You may use `&nbsp;`, `<br>`, `<wbr>`, `&shy;`, etc. to control word wrap. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed."
     },
     "positive-value-indicator": {
-        "message": "+[ቁጥር]",
+        "message": "+{Number}",
         "description": "This is used to indicate when a numeric value is positive -- like '+500'. This will show when a number is going to be increased by another number. '{Number}' is a placeholder for an integer for decimal value."
     },
     "psicash#mustconnect-modal#title": {


### PR DESCRIPTION
It had translated the word "Number" instead of leaving it as a placeholder.