### PR TITLE
Change DisableTimeouts functionality

### DIFF
--- a/src/coretransport.cpp
+++ b/src/coretransport.cpp
@@ -413,7 +413,7 @@ bool CoreTransport::WriteParameterFiles(tstring& configFilename, tstring& server
 
     if (Settings::DisableTimeouts())
     {
-        config["NetworkLatencyMultiplier"] = 3.0;
+        config["NetworkLatencyMultiplierLambda"] = 0.1;
     }
 
     if (m_authorizationsProvider) {


### PR DESCRIPTION
Instead of setting a long, fixed latency multiplier, DisableTimeouts now just
sets the random distribution to approximately uniformly select from the
default (or tactics configured) latency multiplier range.

The intent of this change is to avoid unnecessarily long timeouts that
resulted from users incorrectly checking this option, while still often trying
longer timeouts in case they are needed.