### PR TITLE
v161

### DIFF
--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -49,7 +49,7 @@ void FeedbackUpload::StartSendFeedback()
 
 // Called once during IWorkerThread startup.
 bool FeedbackUpload::DoStart()
-{	 
+{
     try
     {
         SendFeedback();
@@ -93,8 +93,7 @@ FeedbackUpload
 FeedbackUpload::FeedbackUpload(const string& diagnosticData,
                                const string& upstreamProxyAddress,
                                const StopInfo& stopInfo)
-    : m_panicked(false),
-      m_uploadStatus(FEEDBACK_UPLOAD_STATUS_IN_PROGRESS),
+    : m_uploadStatus(FEEDBACK_UPLOAD_STATUS_IN_PROGRESS),
       m_diagnosticData(diagnosticData),
       m_stopInfo(stopInfo),
       m_upstreamProxyAddress(upstreamProxyAddress)
@@ -266,7 +265,7 @@ bool FeedbackUpload::DoPeriodicCheck()
     catch (Subprocess::Error& error) {
         my_print(NOT_SENSITIVE, false, _T("%s - caught Subprocess::Error: %s"), __TFUNCTION__, error.GetMessage().c_str());
     }
- 
+
     return false;
 }
 

--- a/src/feedback_upload.h
+++ b/src/feedback_upload.h
@@ -89,7 +89,7 @@ public:
     The upload has either completed successfully or failed.
     */
     bool FeedbackUpload::UploadCompleted() const;
-    
+
     /**
     Feedback upload status. Possible values are defined by the constants
     FEEDBACK_UPLOAD_STATUS{IN_PROGRESS, SUCCESS, FAILED, CANCELLED, ERROR}.
@@ -107,7 +107,7 @@ protected:
     void HandlePsiphonTunnelCoreNotice(const string& noticeType, const string& timestamp, const Json::Value& data);
 
     virtual void SendFeedback();
- 
+
     /**
     May throw FeedbackUploadFailed.
     */
@@ -116,7 +116,6 @@ protected:
 
 protected:
     tstring m_exePath;
-    bool m_panicked;
     atomic<DWORD> m_uploadStatus;
     WorkerThreadSynch m_workerThreadSynch;
     string m_diagnosticData;

--- a/src/psiphon_tunnel_core.cpp
+++ b/src/psiphon_tunnel_core.cpp
@@ -29,7 +29,8 @@
 
 
 PsiphonTunnelCore::PsiphonTunnelCore(IPsiphonTunnelCoreNoticeHandler* noticeHandler, const tstring& exePath)
-    : Subprocess(exePath, this)
+    : Subprocess(exePath, this),
+      m_panicked(false)
 {
     if (noticeHandler == NULL) {
         throw std::exception(__FUNCTION__ ":" STRINGIZE(__LINE__) "noticeHandler null");


### PR DESCRIPTION
Fix: Uninitialized variable was resulting in non-panics being logged in full, potentially exposing sensitive info