### PR TITLE
Fix: write distinct config for feedback upload

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,7 @@
 static const TCHAR* INFO_LINK_PROMPT = _T("About Psiphon 3");
 static const TCHAR* LOCAL_SETTINGS_APPDATA_SUBDIRECTORY = _T("Psiphon3");
 static const TCHAR* LOCAL_SETTINGS_APPDATA_CONFIG_FILENAME = _T("psiphon.config");
+static const TCHAR* LOCAL_SETTINGS_APPDATA_FEEDBACK_CONFIG_FILENAME = _T("feedback.config");
 static const TCHAR* LOCAL_SETTINGS_APPDATA_URL_PROXY_CONFIG_FILENAME = _T("url_proxy.config");
 static const TCHAR* LOCAL_SETTINGS_APPDATA_SERVER_LIST_FILENAME = _T("server_list.dat");
 static const TCHAR* LOCAL_SETTINGS_APPDATA_REMOTE_SERVER_LIST_FILENAME = _T("remote_server_list");

--- a/src/coretransport.cpp
+++ b/src/coretransport.cpp
@@ -232,7 +232,20 @@ void CoreTransport::TransportConnectHelper()
 
     WriteParameterFilesOut out;
     WriteParameterFilesIn in;
-    in.requestingUrlProxyWithoutTunnel = RequestingUrlProxyWithoutTunnel();
+    bool requestingUrlProxyWithoutTunnel = RequestingUrlProxyWithoutTunnel();
+    in.requestingUrlProxyWithoutTunnel = requestingUrlProxyWithoutTunnel;
+    if (requestingUrlProxyWithoutTunnel) {
+        // RequireUrlProxyWithoutTunnel mode has a distinct config file so that
+        // it won't conflict with a standard CoreTransport which may already be
+        // running.
+        // TODO: there's still a remote chance that concurrently spawned url proxy
+        // instances could clobber each other's config file?
+        in.configFilename = WStringToUTF8(LOCAL_SETTINGS_APPDATA_URL_PROXY_CONFIG_FILENAME);
+    }
+    else {
+        in.configFilename = WStringToUTF8(LOCAL_SETTINGS_APPDATA_CONFIG_FILENAME);
+    }
+
     in.upstreamProxyAddress = GetUpstreamProxyAddress();
     in.encodedAuthorizations = encodedAuthorizations;
     in.tempConnectServerEntry = m_tempConnectServerEntry;
@@ -262,7 +275,7 @@ void CoreTransport::TransportConnectHelper()
 
     // Run core process; it will begin establishing a tunnel
 
-    if (!SpawnCoreProcess(out.configFilename, out.serverListFilename))
+    if (!SpawnCoreProcess(out.configFilePath, out.serverListFilename))
     {
         throw TransportFailed();
     }

--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -144,6 +144,9 @@ void FeedbackUpload::SendFeedbackHelper()
     WriteParameterFilesOut out;
     WriteParameterFilesIn in;
     in.requestingUrlProxyWithoutTunnel = false;
+    // FeedbackUpload mode has a distinct config file so that it won't conflict
+    // with a standard CoreTransport which may already be running.
+    in.configFilename = WStringToUTF8(LOCAL_SETTINGS_APPDATA_FEEDBACK_CONFIG_FILENAME);
     in.upstreamProxyAddress = m_upstreamProxyAddress;
     in.encodedAuthorizations = Json::Value(Json::arrayValue);
     in.tempConnectServerEntry = NULL;
@@ -154,7 +157,7 @@ void FeedbackUpload::SendFeedbackHelper()
     }
 
     // Run subprocess; it will begin uploading the feedback
-    if (!SpawnFeedbackUploadProcess(out.configFilename, m_diagnosticData))
+    if (!SpawnFeedbackUploadProcess(out.configFilePath, m_diagnosticData))
     {
         throw FeedbackUploadFailed();
     }

--- a/src/psiphon_tunnel_core_utilities.cpp
+++ b/src/psiphon_tunnel_core_utilities.cpp
@@ -219,29 +219,18 @@ bool WriteParameterFiles(const WriteParameterFilesIn& in, WriteParameterFilesOut
     Json::FastWriter jsonWriter;
     configDataStream << jsonWriter.write(config);
 
-    // RequireUrlProxyWithoutTunnel mode has a distinct config file so that
-    // it won't conflict with a standard CoreTransport which may already be
-    // running. Also, this mode omits the server list file, since it's not
-    // trying to establish a tunnel.
-    // TODO: there's still a remote chance that concurrently spawned url
-    // proxy instances could clobber each other's config file?
-
     auto configPath = filesystem::path(dataStoreDirectory);
-    if (in.requestingUrlProxyWithoutTunnel)
-    {
-        configPath.append(LOCAL_SETTINGS_APPDATA_URL_PROXY_CONFIG_FILENAME);
-    }
-    else
-    {
-        configPath.append(LOCAL_SETTINGS_APPDATA_CONFIG_FILENAME);
-    }
-    out.configFilename = configPath;
+    configPath.append(in.configFilename);
+    out.configFilePath = configPath;
 
-    if (!WriteFile(out.configFilename, configDataStream.str()))
+    if (!WriteFile(out.configFilePath, configDataStream.str()))
     {
         my_print(NOT_SENSITIVE, false, _T("%s - write config file failed (%d)"), __TFUNCTION__, GetLastError());
         return false;
     }
+
+    // RequireUrlProxyWithoutTunnel mode omits the server list file, since
+    // it's not trying to establish a tunnel.
 
     if (!in.requestingUrlProxyWithoutTunnel)
     {

--- a/src/psiphon_tunnel_core_utilities.h
+++ b/src/psiphon_tunnel_core_utilities.h
@@ -39,6 +39,7 @@ string GetUpstreamProxyAddress();
 // Input arguments to WriteParameterFiles
 struct WriteParameterFilesIn {
     bool requestingUrlProxyWithoutTunnel;
+    string configFilename;
     string upstreamProxyAddress;
     Json::Value encodedAuthorizations;
     const ServerEntry* tempConnectServerEntry;
@@ -46,7 +47,7 @@ struct WriteParameterFilesIn {
 
 // Ouput information from WriteParameterFiles
 struct WriteParameterFilesOut {
-    tstring configFilename;
+    tstring configFilePath;
     tstring serverListFilename;
     tstring oldClientUpgradeFilename;
     tstring newClientUpgradeFilename;


### PR DESCRIPTION
Fixes CoreTransport and FeedbackUpload both writing their Psiphon
config file to the same path. This created the potential for each
to overwrite the config file written by the other, which would
result in unexpected behaviour.