### PR TITLE
change non-debug logs to debug

### DIFF
--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -168,7 +168,7 @@ bool FeedbackUpload::SpawnFeedbackUploadProcess(const tstring& configFilename, c
 {
     tstring exePath;
     if (!GetUniqueTempFilename(_T(""), exePath)) {
-        my_print(NOT_SENSITIVE, false, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+        my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }
 

--- a/src/local_proxy.cpp
+++ b/src/local_proxy.cpp
@@ -92,7 +92,7 @@ bool LocalProxy::DoStart()
     Cleanup(false);
 
     if (!GetUniqueTempFilename(_T(""), m_polipoPath)) {
-        my_print(NOT_SENSITIVE, false, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+        my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }
 


### PR DESCRIPTION
The log output is highly unlikely to be actionable.