### PR TITLE
make temporary executable names more random

### DIFF
--- a/src/coretransport.cpp
+++ b/src/coretransport.cpp
@@ -329,8 +329,14 @@ bool CoreTransport::SpawnCoreProcess(const tstring& configFilename, const tstrin
     // We will be using a random file name for the executable. This will help
     // prevent blocking of "psiphon-tunnel-core.exe". See:
     // https://github.com/Psiphon-Inc/psiphon-issues/issues/828
+    // The goal is to make the running of this file as unblockable as possible,
+    // for example by a Windows Group Policy. Originally we always used the
+    // the same filename and it was trivially blocked from running. We are now
+    // using a filename with random length and random characters, which should
+    // be extremely difficult to create a glob-based matching rule for. The
+    // extension is also only included randomly (half the time).
     tstring exePath;
-    if (!GetUniqueTempFilename(_T(""), exePath)) {
+    if (!GetUniqueTempFilename(_T(".exe"), exePath, true)) {
         my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }

--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -166,29 +166,42 @@ void FeedbackUpload::SendFeedbackHelper()
 
 bool FeedbackUpload::SpawnFeedbackUploadProcess(const tstring& configFilename, const string& diagnosticData)
 {
-    tstring exePath;
-    if (!GetUniqueTempFilename(_T(".exe"), exePath, true)) {
-        my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
-        return false;
+    bool startSuccess = false;
+    for (int i = 0; i < 5; i++) {
+        tstring exePath;
+        if (!GetUniqueTempFilename(_T(".exe"), exePath, i)) {
+            my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+            // This is unlikely to be recoverable with more attempts
+            return false;
+        }
+
+        if (!ExtractExecutable(IDR_PSIPHON_TUNNEL_CORE_EXE, exePath))
+        {
+            my_print(NOT_SENSITIVE, true, _T("%s:%d - ExtractExecutable failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+
+            // This string contains PII (the username in the temp path) but won't be logged
+            auto errorDetail = WStringToUTF8(exePath + L"\n\n" + SystemErrorMessage(GetLastError()));
+            UI_Notice("PsiphonUI::FileError", errorDetail);
+
+            continue;
+        }
+
+        tstringstream commandLineFlags;
+        commandLineFlags << _T(" --config \"") << configFilename << _T("\" --feedbackUpload");
+
+        m_psiphonTunnelCore = make_unique<PsiphonTunnelCore>(this, exePath);
+        if (!m_psiphonTunnelCore->SpawnSubprocess(commandLineFlags.str())) {
+            my_print(NOT_SENSITIVE, false, _T("%s:%d - SpawnSubprocess failed"), __TFUNCTION__, __LINE__);
+            // The PsiphonTunnelCore (Subprocess) destructor will clean up the executable file
+            continue;
+        }
+
+        startSuccess = true;
+        break;
     }
 
-    if (!ExtractExecutable(IDR_PSIPHON_TUNNEL_CORE_EXE, exePath))
-    {
-        my_print(NOT_SENSITIVE, true, _T("%s:%d - ExtractExecutable failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
-
-        // This string contains PII (the username in the temp path) but won't be logged
-        auto errorDetail = WStringToUTF8(exePath + L"\n\n" + SystemErrorMessage(GetLastError()));
-        UI_Notice("PsiphonUI::FileError", errorDetail);
-
-        return false;
-    }
-
-    tstringstream commandLineFlags;
-    commandLineFlags << _T(" --config \"") << configFilename << _T("\" --feedbackUpload");
-
-    m_psiphonTunnelCore = make_unique<PsiphonTunnelCore>(this, exePath);
-    if (!m_psiphonTunnelCore->SpawnSubprocess(commandLineFlags.str())) {
-        my_print(NOT_SENSITIVE, false, _T("%s:%d - SpawnSubprocess failed"), __TFUNCTION__, __LINE__);
+    if (!startSuccess) {
+        my_print(NOT_SENSITIVE, true, _T("%s:%d - process spawning failed utterly: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }
 

--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -167,7 +167,7 @@ void FeedbackUpload::SendFeedbackHelper()
 bool FeedbackUpload::SpawnFeedbackUploadProcess(const tstring& configFilename, const string& diagnosticData)
 {
     tstring exePath;
-    if (!GetUniqueTempFilename(_T(""), exePath)) {
+    if (!GetUniqueTempFilename(_T(".exe"), exePath, true)) {
         my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }

--- a/src/local_proxy.cpp
+++ b/src/local_proxy.cpp
@@ -91,40 +91,56 @@ bool LocalProxy::DoStart()
     // Ensure we start from a disconnected/clean state
     Cleanup(false);
 
-    if (!GetUniqueTempFilename(_T(".exe"), m_polipoPath, true)) {
-        my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
-        return false;
-    }
-
-    if (!ExtractExecutable(IDR_POLIPO_EXE, m_polipoPath))
-    {
-        return false;
-    }
-
     int localHttpProxyPort = Settings::LocalHttpProxyPort();
-    if (localHttpProxyPort == 0)
-    {
-        // Choose the port automatically
-        localHttpProxyPort = 1024;
-        if (!TestForOpenPort(localHttpProxyPort, 60000, m_stopInfo))
-        {
-            my_print(NOT_SENSITIVE, false, _T("HTTP proxy could not find an available port."));
+
+    bool startSuccess = false;
+    for (int i = 0; i < 5; i++) {
+        if (!GetUniqueTempFilename(_T(".exe"), m_polipoPath, i)) {
+            my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+            // This is unlikely to be recoverable with more attempts
             return false;
         }
-    }
-    else
-    {
-        // Require the specified port
-        if (!TestForOpenPort(localHttpProxyPort, 0, m_stopInfo))
+
+        if (!ExtractExecutable(IDR_POLIPO_EXE, m_polipoPath))
         {
-            my_print(NOT_SENSITIVE, false, _T("Port is not available for HTTP proxy to listen on: %d"), localHttpProxyPort);
-            return false;
+            continue;
         }
+
+        if (localHttpProxyPort == 0)
+        {
+            // Choose the port automatically
+            localHttpProxyPort = 1024;
+            if (!TestForOpenPort(localHttpProxyPort, 60000, m_stopInfo))
+            {
+                my_print(NOT_SENSITIVE, false, _T("HTTP proxy could not find an available port."));
+                // This is unlikely to be recoverable with more attempts
+                return false;
+            }
+        }
+        else
+        {
+            // Require the specified port
+            if (!TestForOpenPort(localHttpProxyPort, 0, m_stopInfo))
+            {
+                my_print(NOT_SENSITIVE, false, _T("Port is not available for HTTP proxy to listen on: %d"), localHttpProxyPort);
+                // This is unlikely to be recoverable with more attempts
+                return false;
+            }
+        }
+
+        if (!StartPolipo(localHttpProxyPort))
+        {
+            // The executable file is deleted by Cleanup
+            Cleanup(false);
+            continue;
+        }
+
+        startSuccess = true;
+        break;
     }
 
-    if (!StartPolipo(localHttpProxyPort))
-    {
-        Cleanup(false);
+    if (!startSuccess) {
+        my_print(NOT_SENSITIVE, true, _T("%s:%d - startup failed utterly: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }
 
@@ -200,7 +216,14 @@ void LocalProxy::Cleanup(bool doStats)
     auto deleteExe = finally([=]() {
         if (!m_polipoPath.empty() && !DeleteFile(m_polipoPath.c_str()))
         {
-            my_print(NOT_SENSITIVE, true, _T("%s:%d - DeleteFile failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+            // We sometimes see random DeleteFile failures with ERROR_ACCESS_DENIED.
+            // This may be due to ongoing virus scanning of a newly written executable.
+            // Sleeping seems effective in allowing a subsequent DeleteFile to succeed,
+            // although the exact time needed to sleep surely varies by system.
+            Sleep(1000);
+            if (!DeleteFile(m_polipoPath.c_str())) {
+                my_print(NOT_SENSITIVE, true, _T("%s:%d - DeleteFile failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+            }
         }
         m_polipoPath.clear();
     });

--- a/src/local_proxy.cpp
+++ b/src/local_proxy.cpp
@@ -91,7 +91,7 @@ bool LocalProxy::DoStart()
     // Ensure we start from a disconnected/clean state
     Cleanup(false);
 
-    if (!GetUniqueTempFilename(_T(""), m_polipoPath)) {
+    if (!GetUniqueTempFilename(_T(".exe"), m_polipoPath, true)) {
         my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
         return false;
     }

--- a/src/psiphon_tunnel_core_utilities.cpp
+++ b/src/psiphon_tunnel_core_utilities.cpp
@@ -163,7 +163,7 @@ bool WriteParameterFiles(const WriteParameterFilesIn& in, WriteParameterFilesOut
             // as each other. So we'll give each one a unique, temporary directory.
 
             tstring tempDir;
-            if (!GetUniqueTempDir(tempDir, true))
+            if (!GetUniqueTempDir(tempDir))
             {
                 my_print(NOT_SENSITIVE, false, _T("%s - GetUniqueTempDir failed (%d)"), __TFUNCTION__, GetLastError());
                 return false;

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -54,10 +54,11 @@ bool GetSysTempPath(filesystem::path& o_path);
 // Returns true on success, false otherwise. Caller can check GetLastError() on failure.
 bool GetUniqueTempDir(tstring& o_path, bool create);
 
-// Makes an absolute path for a unique filename. If `extension` is nonempty,
-// the filename will have that extension.
-// Returns true on success, false otherwise. Caller can check GetLastError() on failure.
-bool GetUniqueTempFilename(const tstring& extension, tstring& o_filepath);
+/// Makes an absolute path for a unique filename. If `extension` is nonempty,
+/// the filename will have that extension. If `randomlyDropExtension` is true,
+/// the extension will be discarded approximately half the time.
+/// Returns true on success, false otherwise. Caller can check GetLastError() on failure.
+bool GetUniqueTempFilename(const tstring& extension, tstring& o_filepath, bool randomlyDropExtension=false);
 
 /// Retrieves the path of the current executable. Returns false on error.
 bool GetOwnExecutablePath(tstring& o_path);
@@ -184,10 +185,6 @@ std::tstring SystemErrorMessage(DWORD errorCode);
  */
 
 tstring GetISO8601DatetimeString();
-
-// Makes a GUID string. Returns true on success, false otherwise.
-// If withBraces is true, there will be curly braces as prefix and suffix.
-bool MakeGUID(tstring& o_guid, bool withBraces=true);
 
 /// Randomly shuffle a vector of values.
 template <typename IteratorType>

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -47,18 +47,22 @@ bool DirectoryExists(LPCTSTR szPath);
 // dir with no suffixes is always created.)
 bool GetPsiphonDataPath(const vector<tstring>& pathSuffixes, bool ensureExists, tstring& o_path);
 
+/// Returns the system temp path to be used for Psiphon files.
 bool GetSysTempPath(filesystem::path& o_path);
 
-// Makes an absolute path to a unique temp directory.
-// If `create` is true, the directory will also be created.
-// Returns true on success, false otherwise. Caller can check GetLastError() on failure.
-bool GetUniqueTempDir(tstring& o_path, bool create);
-
-/// Makes an absolute path for a unique filename. If `extension` is nonempty,
-/// the filename will have that extension. If `randomlyDropExtension` is true,
-/// the extension will be discarded approximately half the time.
+/// Makes an absolute path to a unique temp directory. The directory is created.
+/// `depth` indicates how many subdirectories under the temp root should be used.
+/// If `depth` is zero, then the temp directory itself is returned.
+/// `depth` must not be larger than 10, as randomness is lost and the path can get too long.
 /// Returns true on success, false otherwise. Caller can check GetLastError() on failure.
-bool GetUniqueTempFilename(const tstring& extension, tstring& o_filepath, bool randomlyDropExtension=false);
+bool GetUniqueTempDir(tstring& o_path, int depth=1);
+
+/// Makes an absolute path for a unique filename. It may include one or more subdirectories.
+/// If `extension` is nonempty, the filename will have that extension.
+/// If `attempt` is greater than zero, the extension will alternate between being included and not.
+/// (This is intended to be used when creating executable files.)
+/// Returns true on success, false otherwise. Caller can check GetLastError() on failure.
+bool GetUniqueTempFilename(const tstring& extension, tstring& o_filepath, int attempt=-1);
 
 /// Retrieves the path of the current executable. Returns false on error.
 bool GetOwnExecutablePath(tstring& o_path);


### PR DESCRIPTION
It was still possible to block the executables using a GUID glob pattern -- with some collateral damage, but not enough.. Now the filenames are pattern-less: random string, random length, randomly-present extension.

Even more of a fix for https://github.com/Psiphon-Inc/psiphon-issues/issues/828