### PR TITLE
always try a fixed filename first

### DIFF
--- a/src/coretransport.cpp
+++ b/src/coretransport.cpp
@@ -326,26 +326,16 @@ void CoreTransport::TransportConnectHelper()
 
 bool CoreTransport::SpawnCoreProcess(const tstring& configFilename, const tstring& serverListFilename)
 {
-    // When Settings::ExposeLocalProxiesToLAN is true, we are exposing the local proxy
-    // to the LAN (i.e., listen on all IP addresses; allow connections from external
-    // clients) there is a Windows Firewall prompt to allow the subprocess -- by path
-    // and name -- to accept external connections. In that case there are two things
-    // we don't want to do:
-    // 1. Show a new prompt every time there's a connection attempt and a new
-    //    subprocess is spawned. This means that we can't use a random name every time.
-    // 2. Show a prompt with an filename that is unintelligible to the user. This means
-    //    that we don't want to use a random name at all.
-    bool useFixedSubprocessName = Settings::ExposeLocalProxiesToLAN();
-
     bool startSuccess = false;
-    for (int i = 0; i < 5; i++) {
-        if (i > 0 && useFixedSubprocessName) {
-            // We've already had our one attempt
-            break;
-        }
-
+    // We will try a static filename and then five attempts with random filenames
+    for (int i = -1; i < 5; i++) {
         tstring exePath;
-        if (useFixedSubprocessName) {
+        if (i < 0) {
+            // First we try a static filename. This will work for most people, it will not
+            // cause repeated Windows Firewall prompts (in "listen on all interfaces" mode),
+            // the FW prompt will have an intelligible filename, and it won't cause some
+            // security software (like Symantec Endpoint Protection) to give prompts about
+            // the random filenames.
             filesystem::path tempPath;
             if (!GetSysTempPath(tempPath)) {
                 my_print(NOT_SENSITIVE, true, _T("%s:%d - GetSysTempPath failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
@@ -359,12 +349,12 @@ bool CoreTransport::SpawnCoreProcess(const tstring& configFilename, const tstrin
             // prevent blocking of "psiphon-tunnel-core.exe". See:
             // https://github.com/Psiphon-Inc/psiphon-issues/issues/828
             // The goal is to make the running of this file as unblockable as possible,
-            // for example by a Windows Group Policy. Originally we always used the the
-            // same filename and it was trivially blocked from running. We are now using a
+            // for example by a Windows Group Policy. Originally we always used the same
+            // filename and it was trivially blocked from running. We are now using a
             // filename with random length and random characters, under a random depth of
             // subdirectories, which should be extremely difficult to create a glob-based
             // matching rule for.
-            // The extension is also only included half the time. We will make multiple
+            // The extension is also included only half the time. We will make multiple
             // attempts to ensure that various filename configurations are tried.
             if (!GetUniqueTempFilename(_T(".exe"), exePath, i)) {
                 my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());

--- a/src/feedback_upload.cpp
+++ b/src/feedback_upload.cpp
@@ -166,13 +166,25 @@ void FeedbackUpload::SendFeedbackHelper()
 
 bool FeedbackUpload::SpawnFeedbackUploadProcess(const tstring& configFilename, const string& diagnosticData)
 {
+    // See CoreTransport::SpawnCoreProcess for an explanation of the filename logic
     bool startSuccess = false;
-    for (int i = 0; i < 5; i++) {
+    for (int i = -1; i < 5; i++) {
         tstring exePath;
-        if (!GetUniqueTempFilename(_T(".exe"), exePath, i)) {
-            my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
-            // This is unlikely to be recoverable with more attempts
-            return false;
+        if (i < 0) {
+            filesystem::path tempPath;
+            if (!GetSysTempPath(tempPath)) {
+                my_print(NOT_SENSITIVE, true, _T("%s:%d - GetSysTempPath failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+                return false;
+            }
+
+            exePath = tempPath / "psiphon-feedback.exe";
+        }
+        else {
+            if (!GetUniqueTempFilename(_T(".exe"), exePath, i)) {
+                my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+                // This is unlikely to be recoverable with more attempts
+                return false;
+            }
         }
 
         if (!ExtractExecutable(IDR_PSIPHON_TUNNEL_CORE_EXE, exePath))

--- a/src/local_proxy.cpp
+++ b/src/local_proxy.cpp
@@ -93,12 +93,24 @@ bool LocalProxy::DoStart()
 
     int localHttpProxyPort = Settings::LocalHttpProxyPort();
 
+    // See CoreTransport::SpawnCoreProcess for an explanation of the filename logic
     bool startSuccess = false;
-    for (int i = 0; i < 5; i++) {
-        if (!GetUniqueTempFilename(_T(".exe"), m_polipoPath, i)) {
-            my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
-            // This is unlikely to be recoverable with more attempts
-            return false;
+    for (int i = -1; i < 5; i++) {
+        if (i < 0) {
+            filesystem::path tempPath;
+            if (!GetSysTempPath(tempPath)) {
+                my_print(NOT_SENSITIVE, true, _T("%s:%d - GetSysTempPath failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+                return false;
+            }
+
+            m_polipoPath = tempPath / "psiphon-local-proxy.exe";
+        }
+        else {
+            if (!GetUniqueTempFilename(_T(".exe"), m_polipoPath, i)) {
+                my_print(NOT_SENSITIVE, true, _T("%s:%d - GetUniqueTempFilename failed: %d"), __TFUNCTION__, __LINE__, GetLastError());
+                // This is unlikely to be recoverable with more attempts
+                return false;
+            }
         }
 
         if (!ExtractExecutable(IDR_POLIPO_EXE, m_polipoPath))


### PR DESCRIPTION
This approach should give good behaviour for users affected by Windows Group Policy and so needing random names, those using listen-on-all-interfaces mode and so wanting a fixed filename, and those who run something like Symantec Endpoint Protection, which also benefits from a fixed filename.